### PR TITLE
autofocus & swiper height

### DIFF
--- a/packages/components/src/component/search/search.weapp.js
+++ b/packages/components/src/component/search/search.weapp.js
@@ -51,6 +51,7 @@ const Search = ({
           confirmType='search'
           value={value}
           focus={autoFocus}
+          autoFocus={autoFocus}
           onChange={handleChange}
           placeholder={placeholder}
           onConfirm={handleSearch}


### PR DESCRIPTION
1. autofocus字段即将废弃，小程序推荐用focus，但是经过测试focus并不生效，原因未知。解决方法两个都加上
2. swiper的数据改变后，图片不能撑开容器，给容器height 100%自己撑开