### PR TITLE
fix：多日下单组件 过滤空数组情况v2

### DIFF
--- a/packages/service-time/src/component/multi_order_receive_time_picker.js
+++ b/packages/service-time/src/component/multi_order_receive_time_picker.js
@@ -55,12 +55,15 @@ const getCycList = ({
 }
 
 const getStartCycleList = (cycleList) => {
-  return _.map(cycleList, (list, i) => {
-    if (i === cycleList.length - 1) {
-      return _.slice(list, 0, -1)
-    }
-    return list
-  })
+  return _.filter(
+    _.map(cycleList, (list, i) => {
+      if (i === cycleList.length - 1) {
+        return _.slice(list, 0, -1)
+      }
+      return list
+    }),
+    (list) => list.length
+  )
 }
 
 const getEndCycleList = (startValue, cycleList) => {


### PR DESCRIPTION
```js
const columnGenerator = (cycList) => {
  return _.map(cycList, (v) => ({
    text: v[0].moment.isBefore(moment().endOf('day'))
      ? getLocale('当日')
      : getLocale('次日'),
    value: v[0].moment.isBefore(moment().endOf('day')) ? 0 : 1,
    children: v,
  }))
}
```
`cycList`可能是空数组，会导致`v[0].moment`报错  
fix: `getStartCycleList`方法过滤调空数组