### PR TITLE
fix: .yarnrc use yarn v1 compatible format

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,1 @@
-registry: https://registry.npmmirror.com/
+registry "https://registry.npmmirror.com/"


### PR DESCRIPTION
yarn v1 does not support colon-separated key-value syntax in .yarnrc. Changed from `registry: url` to `registry "url"` format.